### PR TITLE
feat: Allow to remove Automerge documents

### DIFF
--- a/packages/feathers-automerge-server/src/sync-service.ts
+++ b/packages/feathers-automerge-server/src/sync-service.ts
@@ -144,6 +144,33 @@ export class AutomergeSyncServive {
     return info
   }
 
+  async remove(url: string) {
+    if (!this.rootDocument) {
+      throw new Error('Root document not available')
+    }
+
+    const docs = this.rootDocument.doc().documents
+    const index = docs.findIndex((d) => d.url === url)
+
+    if (index === -1) {
+      throw new NotFound(`Document with URL ${url} not found`)
+    }
+
+    const info = docs[index]
+
+    await new Promise<void>((resolve) => {
+      this.rootDocument!.change((doc) => {
+        doc.documents.splice(index, 1)
+        resolve()
+      })
+    })
+
+    this.repo.delete(url as AnyDocumentId)
+    delete this.docHandles[url]
+
+    return info
+  }
+
   async handleEvent(servicePath: string, eventName: string, data: any) {
     if (!this.app) {
       throw new Error('Feathers application not available. Did you call app.listen() or app.setup()?')

--- a/packages/feathers-automerge-server/test/index.test.ts
+++ b/packages/feathers-automerge-server/test/index.test.ts
@@ -212,4 +212,16 @@ describe('@kalisio/feathers-automerge-server', () => {
     await removedTodo
     await expect(() => app.service('todos').get(3)).rejects.toThrow()
   })
+
+  it('can delete a document', async () => {
+    const info = await app.service('automerge').create({
+      query: {
+        username: 'deleteme'
+      }
+    })
+
+    const deletedDocument = await app.service('automerge').remove(info.url)
+    expect(deletedDocument).toEqual(info)
+    await expect(() => app.service('automerge').get(info.url)).rejects.toThrow()
+  })
 })

--- a/packages/feathers-automerge/src/index.ts
+++ b/packages/feathers-automerge/src/index.ts
@@ -25,6 +25,14 @@ export type AutomergeAppConfig = {
   syncHandle: Promise<SyncDocumentHandle> | null
 }
 
+export type AutomergeClientConfig = {
+  syncOptions: AutomergeClientOptions
+  syncHandle: Promise<SyncDocumentHandle> | null
+  repo: Repo
+}
+
+export type AutomergeClientApp = Application<any, AutomergeClientConfig>
+
 export function createBrowserRepo(wsUrl: string) {
   return new Repo({
     network: [new BrowserWebSocketClientAdapter(wsUrl)],
@@ -32,8 +40,8 @@ export function createBrowserRepo(wsUrl: string) {
   })
 }
 
-export async function getDocHandle(app: Application, url: AutomergeUrl): Promise<SyncDocumentHandle> {
-  const repo: Repo = app.get('repo')
+export async function getDocHandle(app: AutomergeClientApp, url: AutomergeUrl): Promise<SyncDocumentHandle> {
+  const repo = app.get('repo')
 
   if (!repo) {
     throw new Error('Repo not initialized on application')
@@ -42,10 +50,10 @@ export async function getDocHandle(app: Application, url: AutomergeUrl): Promise
   return repo.find<SyncServiceDocument>(url)
 }
 
-export async function initAutomergeServices(app: Application, url: AutomergeUrl) {
+export async function initAutomergeServices(app: AutomergeClientApp, url: AutomergeUrl) {
   app.set('syncHandle', getDocHandle(app, url))
 
-  const handle: SyncDocumentHandle = await app.get('syncHandle')
+  const handle = await app.get('syncHandle')!
   const doc = await handle.doc()
 
   Object.keys(doc).forEach((path) => {
@@ -64,8 +72,8 @@ export async function initAutomergeServices(app: Application, url: AutomergeUrl)
   })
 }
 
-export async function syncOffline(app: Application, payload: SyncServiceCreate) {
-  const { syncServicePath } = app.get('syncOptions') as AutomergeClientOptions
+export async function syncOffline(app: AutomergeClientApp, payload: SyncServiceCreate) {
+  const { syncServicePath } = app.get('syncOptions')
   const info: SyncServiceInfo = await app.service(syncServicePath).create(payload)
 
   if (typeof window !== 'undefined' && window.localStorage) {
@@ -77,8 +85,8 @@ export async function syncOffline(app: Application, payload: SyncServiceCreate) 
   return info
 }
 
-export async function stopSyncOffline(app: Application) {
-  const handle: SyncDocumentHandle = await app.get('syncHandle')
+export async function stopSyncOffline(app: AutomergeClientApp, remove = false) {
+  const handle = await app.get('syncHandle')
 
   if (!handle) {
     return
@@ -94,15 +102,20 @@ export async function stopSyncOffline(app: Application) {
     })
   )
 
+  app.get('repo').delete(handle.documentId)
   app.set('syncHandle', null)
 
   if (typeof window !== 'undefined' && window.localStorage) {
     window.localStorage.removeItem(LOCALSTORAGE_KEY)
   }
+
+  if (remove) {
+    await app.service('automerge').remove(handle.documentId)
+  }
 }
 
 export function automergeClient(options: AutomergeClientOptions) {
-  return function (app: Application) {
+  return function (app: AutomergeClientApp) {
     const repo = options.repo ?? createBrowserRepo(options.syncServerUrl)
 
     app.set('syncOptions', options)


### PR DESCRIPTION
This PR removes a document from the client when calling `stopSyncOffline` and optionally allows to remove the document from the server as well.

Closes #18
Closes #16